### PR TITLE
faqs, release_notes: resolution to Jen's feedback

### DIFF
--- a/source/faqs.rst
+++ b/source/faqs.rst
@@ -4,31 +4,31 @@ Frequently Asked Questions
 ##########################
 
 :Q:
-    What license(s) does |C| use?
+    **What license(s) does Celadon use?**
 :A:
     |C| consists of permissive and copyleft licenses such as BSD, MIT, Apache and GPL licenses. Use, reproduction and distribution of components of |C| licensed under an open source software license are governed solely by the terms of that open source software license. Please refer and comply to the open source software license found in the source code files or repositories. Certain licenses such as Google Mobile Services or Widevine are not included in |C|.
 
 :Q:
-    What Android desserts are supported in |C|?
+    **What Android desserts are supported in Celadon?**
 :A:
-    The latest Android dessert is supported as soon as Google publicly releases the dessert. Currently,  Oreo MR1 (Android 8.1) is supported by |C|. Please see the Downloads Release page for the latest supported desserts.
+    The latest Android dessert is supported as soon as Google publicly releases the dessert. Please see the :ref:`release_notes` for the latest supported desserts.
 
 :Q:
-    Will the latest |C| work on older hardware that was previously supported?
+    **Will the latest |C| work on older hardware that was previously supported?**
 :A:
     Developers have the option to use an older manifest file to build an image for a previously supported hardware, but |C|'s main focus is enabling on the latest platform. As such, support on older platform may be limited.
 
 :Q:
-    How do I quickly try out |C| to get to know what it is offering?
+    **How do I quickly try out |C| to get to know what it is offering?**
 :A:
     The prebuilt |C| installer image is available for downloading and installing on |NUC|. Reference :ref:`install-on-nuc` of the Getting Started Guide to run the |C| prebuilt image.
 
 :Q:
-    How could I start adding software components to my own |C| build?
+    **How could I start adding software components to my own |C| build?**
 :A:
     |C| follows the same practice as Android for adding software components to the build. A tutorial :ref:`add-movidius-ncsdk` is provided as an example to add |Movidius| Hardware Abstraction Layer to |C|.
 
 :Q:
-    I would like to contribute. Would Intel accept my contributions?
+    **I would like to contribute. Would Intel accept my contributions?**
 :A:
     Yes, we welcome contributions! Since Intel is responsible for the product management and core stack of |C|, what ultimately is accepted is at the maintainers' discretion. We will determine if it's a good fit, then contributions will go through a review and verification process in order to maintain quality.

--- a/source/index.rst
+++ b/source/index.rst
@@ -8,5 +8,6 @@
 
    getting_started/getting_started
    tutorials/tutorials
+   release_notes
    references
    faqs

--- a/source/release_notes.rst
+++ b/source/release_notes.rst
@@ -1,0 +1,4 @@
+.. _release_notes:
+
+Release Notes
+#############


### PR DESCRIPTION
1. add placeholder for the Release Notes page
2. make the FAQ questions bolded

Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>