### PR TITLE
release_notes: 2 known issues had been fixed

### DIFF
--- a/source/release_notes.rst
+++ b/source/release_notes.rst
@@ -65,6 +65,4 @@ SD card                        OK
 Known Issues
 ------------
 
-* Audio over USB headset and BT headset not working, but able to hear on 3.5mm Audio jack.
-* Green patch seen while playing few videos using native video player.
 * Disturbances observed during local video play


### PR DESCRIPTION
Updated from @arun1778 that the audio over USB and BT headset issue, and the issue of observing green patch during the video playback had been fixed. Remove them from the known issue list accordingly.

Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>