### PR TITLE
all: reformat and add software debugging tips tutorial

### DIFF
--- a/blob/celadon_gdb.sh
+++ b/blob/celadon_gdb.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+if [ -z $ANDROID_PRODUCT_OUT ]; then
+	echo "Run source build/envsetup.sh and lunch <target> before executing this script"
+	exit
+fi
+
+PROCNAME=
+FILE=
+if [ $# -lt 1 ]; then
+    echo -n "Enter the name of process to debug on android side: "
+    read tmp
+    PROCNAME=tmp
+else
+    PROCNAME=$1
+fi
+
+FILE=$(find $ANDROID_PRODUCT_OUT/{system,vendor} -name $PROCNAME)
+FILE=$(echo $FILE | sed -e "s|$ANDROID_PRODUCT_OUT/||")
+
+if [ -z $FILE ]; then
+	echo "Unable to find exectuable in vendor/system"
+	echo "exiting..."
+	exit
+fi
+
+PROCPID=$(adb shell pidof "$PROCNAME")
+echo $PROCPID
+
+echo "set auto-load safe-path /" > ~/.gdbinit
+echo "file $ANDROID_PRODUCT_OUT/$FILE" > .gdbinit
+echo "symbol-file $ANDROID_PRODUCT_OUT/symbols/$FILE" >> .gdbinit
+echo "set sysroot $ANDROID_PRODUCT_OUT/symbols" >> .gdbinit
+echo "set solib-search-path $ANDROID_PRODUCT_OUT/symbols/vendor/lib64:$ANDROID_PRODUCT_OUT/symbols/system/lib64:$ANDROID_PRODUCT_OUT" >> .gdbinit
+echo "target remote localhost:6000" >> .gdbinit
+
+adb shell gdbserver64 :6000 --attach "$PROCPID" &
+adb forward tcp:6000 tcp:6000
+gdb

--- a/source/getting_started/build-source.rst
+++ b/source/getting_started/build-source.rst
@@ -60,14 +60,14 @@ Optionally, delete existing output of any previous build with the following comm
 
     $ make clobber
 
-Enter the following commands to initialize the build variables with the ``envsetup.sh`` script and to select the |C| build target. You can run ``lunch`` with no arguments in order to choose different build variants.
+Enter the following commands to initialize the build variables with the *envsetup.sh* script and to select the |C| build target. You can run ``lunch`` with no arguments in order to choose different build variants.
 
 .. code-block:: bash
 
     $ source build/envsetup.sh
     $ lunch celadon-userdebug
 
-Build the |C| installer image with the following command. Replace the ``$(proc)`` argument with the number of processor threads on your workstation in order to build the source code with parallel tasks. The generated image is available at **out/target/product/celadon/celadon.img** after the build. You can follow :ref:`install-on-nuc` of this guide to flash the installer image to a removable USB drive and install |C| on a |NUC|.
+Build the |C| installer image with the following command. Replace the *$(proc)* argument with the number of processor threads on your workstation in order to build the source code with parallel tasks. The generated image is available at **out/target/product/celadon/celadon.img** after the build. You can follow :ref:`install-on-nuc` of this guide to flash the installer image to a removable USB drive and install |C| on a |NUC|.
 
 .. code-block:: bash
 

--- a/source/getting_started/install-run.rst
+++ b/source/getting_started/install-run.rst
@@ -27,7 +27,7 @@ Prepare a |C| installer USB flash drive
 
 Download the prebuilt |C| installer package described in the previous section, uncompress the ZIP file and burn the installer image onto a USB flash drive. The USB flash drive will be used to bootstrap the |NUC| target device, format the disk partitions on the target device, and install |C| images to the disk partitions required by Android. You can use `Rufus <https://rufus.akeo.ie/>`_ or a similar tool to create a bootable USB drive on Windows. Alternatively, use the disk-dump command ``dd`` on any Linux system to create a |C| installer USB drive.
 
-.. note::
+.. warning::
     **Caution:** *The following commands will format the USB flash drive, and destroy all its existing content. Backup your data before proceeding.*
 
 Create |C| installer USB drive in Windows
@@ -57,7 +57,7 @@ Open a terminal window and go to the directory that contains the uncompressed in
     +-sda2           8:2    0   3.8G  0 part [SWAP]
     +-sda3           8:3    0   477M  0 part /boot/efi
 
-In the previous example, ``/dev/sdb`` is assigned to the USB removable drive. This allows you to flash the installer image to the USB drive with the following commands, replacing the drive names with the actual device node observed from the previous ``lsblk`` command.
+In the previous example, **/dev/sdb** is assigned to the USB removable drive. This allows you to flash the installer image to the USB drive with the following commands, replacing the drive names with the actual device node observed from the previous ``lsblk`` command.
 
 .. code-block:: bash
 
@@ -67,10 +67,10 @@ In the previous example, ``/dev/sdb`` is assigned to the USB removable drive. Th
 Install |C| to |NUC| using installer USB drive
 ----------------------------------------------
 
-.. note::
+.. warning::
     **Caution:** *The primary hard drive of the Intel NUC will be completely wiped out. Backup your data before proceeding.*
 
-Plug the bootable USB flash drive into a |NUC| device, power on the device, and press ``F10`` to instruct the device to boot from the USB drive.
+Plug the bootable USB flash drive into a |NUC| device, power on the device, and press **F10** to instruct the device to boot from the USB drive.
 
 .. figure:: images/boot-usb-stick.jpg
     :align: center

--- a/source/tutorials/add-intel-movidius-nnsdk/add-intel-movidius-nnsdk.rst
+++ b/source/tutorials/add-intel-movidius-nnsdk/add-intel-movidius-nnsdk.rst
@@ -24,14 +24,14 @@ Reference the :ref:`build-from-source` section in the Getting Started Guide to s
 Add |Movidius| NN HAL to the build
 ----------------------------------
 
-Google has released the NNAPI support since Android 8.1, and it is  included in the |C| source tree. To add |Movidius| NN HAL to the build, clone the following GitHub repository under the ``external`` directory in the |C| source tree:
+Google has released the NNAPI support since Android 8.1, and it is  included in the |C| source tree. To add |Movidius| NN HAL to the build, clone the following GitHub repository under the *external* directory in the |C| source tree:
 
 .. code-block:: bash
 
     $ cd <celadon_src>
     $ git clone https://github.com/intel/nn-hal.git external/nn-hal
 
-Include ``MvNCAPI.mvcmd``, ``libmvnc``, and ``ncs_test1_app`` packages into the build by adding the following lines to the device makefile ``device/intel/project-celadon/celadon/device.mk`` . These packages represent the NC firmware, NC SDK library, and the testing app respectively.
+Include **MvNCAPI.mvcmd**, **libmvnc**, and **ncs_test1_app** packages into the build by adding the following lines to the device makefile *device/intel/project-celadon/celadon/device.mk* . These packages represent the NC firmware, NC SDK library, and the testing app respectively.
 
 .. code-block:: bash
 
@@ -41,12 +41,12 @@ Include ``MvNCAPI.mvcmd``, ``libmvnc``, and ``ncs_test1_app`` packages into the 
 Communicate with |Movidius| NCS
 -------------------------------
 
-To quickly test the functionality of NCSDK, you must establish an ``adb`` session from the Ubuntu development host to the |NUC| system. This allows you to issue commands over *adb* sessions. Boot up the |NUC| system, configure the WiFi credentials with the Android *Settings* app, and get the assigned IP address from the `Settings->System->About tablet->Status page`.
+To quickly test the functionality of NCSDK, you must establish an *adb* session from the Ubuntu development host to the |NUC| system. This allows you to issue commands over *adb* sessions. Boot up the |NUC| system, configure the WiFi credentials with the Android *Settings* app, and get the assigned IP address from the `Settings->System->About tablet->Status page`.
 
 .. figure:: images/settings-status.png
     :align: center
 
-Install the Android ``adb`` tool on the Ubuntu development host if no `adb` executable is found. Enter the following commands to establish an ``adb`` session:
+Install the Android *adb* tool on the Ubuntu development host if no *adb* executable is found. Enter the following commands to establish an *adb* session:
 
 .. code-block:: bash
 
@@ -58,7 +58,7 @@ Install the Android ``adb`` tool on the Ubuntu development host if no `adb` exec
     * daemon started successfully
     connected to 192.168.1.107:5555
 
-Once the `adb` session is connected, plug in the |Movidius| Neural Compute Stick to the |NUC|. Login to the system and launch the ``ncs_test1_app`` native app with root privilege. The app should  detect the presence of the NCS as shown in following screenshot.
+Once the `adb` session is connected, plug in the |Movidius| Neural Compute Stick to the |NUC|. Login to the system and launch the *ncs_test1_app* native app with root privilege. The app should  detect the presence of the NCS as shown in following screenshot.
 
 .. code-block:: bash
 

--- a/source/tutorials/profiling-system-power-consumption-using-socwatch/profiling-system-power-consumption-using-socwatch.rst
+++ b/source/tutorials/profiling-system-power-consumption-using-socwatch/profiling-system-power-consumption-using-socwatch.rst
@@ -55,11 +55,11 @@ Extract the |SoC| package in the Linux development host, which pulled the source
 
 You **MUST** build the |SoC| kernel modules after completely building the |C| installer image. This is required because the |C| kernel is signed, and the |SoC| kernel modules must be signed with the same keys in order to load into the |C| kernel.
 
-Invoke the ``build_drivers.sh`` script and specify the full paths to the kernel source tree and the sign-file in order to build the kernel modules. The |SoC| kernel modules ``socwatch2_4.ko`` and ``socperf2_0.ko`` are generated in the `drivers/` directory.
+Invoke the *build_drivers.sh* script and specify the full paths to the kernel source tree and the sign-file in order to build the kernel modules. The |SoC| kernel modules *socwatch2_4.ko* and *socperf2_0.ko* are generated in the *drivers/* directory.
 
 .. code-block:: bash
 
-    $ tar zxvf socwatch_android_v2.5.0.tar
+    $ tar zxvf socwatch_android_v2.5.0.tar.gz
     ...
     $ cd socwatch_android_v2.5.0
     $ ./build_drivers.sh -l \
@@ -69,7 +69,7 @@ Invoke the ``build_drivers.sh`` script and specify the full paths to the kernel 
 Set up |SoC| Watch on Intel NUC
 -------------------------------
 
-An ``adb`` session from the Linux development host to the |NUC| is required to set up |SoC| on the |NUC| target system. |C| enables `adb over Ethernet` to communicate to |NUC| through WiFi or wired connections. Connect the |NUC| to the same network as the Linux host and enter the following commands on the Linux host to connect to the |NUC|:
+An *adb* session from the Linux development host to the |NUC| is required to set up |SoC| on the |NUC| target system. |C| enables `adb over Ethernet` to communicate to |NUC| through WiFi or wired connections. Connect the |NUC| to the same network as the Linux host and enter the following commands on the Linux host to connect to the |NUC|:
 
 .. code-block:: bash
 
@@ -79,7 +79,7 @@ An ``adb`` session from the Linux development host to the |NUC| is required to s
     * daemon started successfully *
     connected to 192.168.1.107:5555
 
-The installation of |SoC| software requires root permission. The following commands restart the ``adb`` daemon in privileged mode and re-connects to the |NUC|:
+The installation of |SoC| software requires root permission. The following commands restart the *adb* daemon in privileged mode and re-connects to the |NUC|:
 
 .. code-block:: bash
 
@@ -90,7 +90,7 @@ The installation of |SoC| software requires root permission. The following comma
     * daemon started successfully *
     connected to 192.168.1.107:5555
 
-Run the ``socwatch_android_install.sh`` script in the directory where you extracted the |SoC| package. The script will push the software to the `/data/socwatch` directory on the |NUC|.
+Run the *socwatch_android_install.sh* script in the directory where you extracted the |SoC| package. The script will push the software to the `/data/socwatch` directory on the |NUC|.
 
 .. code-block:: bash
 
@@ -137,7 +137,7 @@ Collect System Power Metrics
 Load |SoC| Kernel Modules
 -------------------------
 
-Establish an ``adb`` session to the |NUC|, enter the Android command line shell, and load the |SoC| kernel modules with the following commands. For Intel platforms powered by the Intel Atom processor family, you must load the ``socperf`` kernel module before the ``socwatch`` kernel module.
+Establish an *adb* session to the |NUC|, enter the Android command line shell, and load the |SoC| kernel modules with the following commands. For Intel platforms powered by the Intel Atom processor family, you must load the *socperf* kernel module before the *socwatch* kernel module.
 
 .. code-block:: bash
 
@@ -149,7 +149,7 @@ Establish an ``adb`` session to the |NUC|, enter the Android command line shell,
 Collect Power Metrics
 ---------------------
 
-Set up the collection environment with the ``setup_socwatch_env.sh`` script. Now, you can start collecting the power consumption data and other metrics with the ``socwatch`` command. For example, the following commands capture the CPU C-state data on |NUC| in 20 seconds. The collected data is stored as a `results.csv` file and other formats, depending on the given parameters. Reference the `Intel SoC Watch for Google Android OS and Linux OS Users Guide <https://software.intel.com/sites/default/files/managed/5a/36/socwatch_android_linux_users_guide.pdf>`_ for more information on the command line parameters, supported feature names, and examples using Intel SoC Watch for energy analysis collection.
+Set up the collection environment with the *setup_socwatch_env.sh* script. Now, you can start collecting the power consumption data and other metrics with the *socwatch* command. For example, the following commands capture the CPU C-state data on |NUC| in 20 seconds. The collected data is stored as a `results.csv` file and other formats, depending on the given parameters. Reference the `Intel SoC Watch for Google Android OS and Linux OS Users Guide <https://software.intel.com/sites/default/files/managed/5a/36/socwatch_android_linux_users_guide.pdf>`_ for more information on the command line parameters, supported feature names, and examples using Intel SoC Watch for energy analysis collection.
 
 .. code-block:: none
 

--- a/source/tutorials/software-debug-tips/software-debug-tips.rst
+++ b/source/tutorials/software-debug-tips/software-debug-tips.rst
@@ -1,0 +1,78 @@
+.. _software-debug-tips:
+
+Software Debugging Tips on |C|
+##############################
+
+In addition the useful tools and techniques documented in the `Debugging Native Android Platform Code <https://source.android.com/devices/tech/debug>`_ section on the AOSP website, this article provides additional information to facilitate the software debugging on |C| devices.
+
+Debugging using gdb
+===================
+
+GNU Debugger (*gdb*) is the most popular debugger for debug C/C++ programs on UNIX systems. You could follow below procedures to tap into a running program, and exercise control over the program to stop execution at a certain point, step through the program one line at a time, and examine variables when problems occur.
+
+#. If your development host does not have *gdb* installed, enter the following commands to install *gdb* tool on your Ubuntu development workstation:
+
+    .. code-block:: bash
+
+        $ sudo apt-get update
+        $ sudo apt-get install gdb
+
+#. A `celadon_gdb.sh <https://raw.githubusercontent.com/projectceladon/celadon-documentation/master/blob/celadon_gdb.sh>`_ script is developed to establish a connection from the local *gdb* program to the *gdbserver* program running on the |C| target device. Since the debugging process requires the program symbol tables and some shared libraries in the |C| build tree, you need to download and save the script in the top-most |C| source directory before initializing the build variables and selecting the |C| build target.
+
+    .. code-block:: bash
+
+        $ cd celadon
+        $ curl -O https://raw.githubusercontent.com/projectceladon/celadon-documentation/master/blob/celadon_gdb.sh
+        $ chmod +x celadon_gdb.sh
+        $ source build/envsetup.sh
+        $ lunch celadon-userdebug
+
+#. Reference the :ref:`build-from-source` section in the Getting Started Guide to build the |C| installer image, and follow the :ref:`install-on-nuc` section to install |C| on a |NUC|.
+
+#. After booting up the |NUC|, set up an *adb* connection from the development host to the |NUC| over Ethernet with the following commands prior the debugging process:
+
+    .. code-block:: none
+
+        $ adb kill-server
+        # Replace the following IP addresses with yours
+        $ adb connect 192.168.1.107
+        * daemon not running. starting it now on port 5037 *
+        * daemon started successfully *
+        connected to 192.168.1.107:5555
+
+#. Restart the *adb* daemon in privileged mode and re-connects to the |NUC|:
+
+    .. code-block:: none
+
+        $ adb root
+        restarting adbd as root
+        $ adb connect 192.168.1.107
+        * daemon not running. starting it now on port 5037 *
+        * daemon started successfully *
+        connected to 192.168.1.107:5555
+
+#. Let's say you want to debug the wireless supplicant daemon *wpa_supplicant*, you can invoke the **celadon_gdb.sh** script with the following command to tap into the running *WPA_supplicant* daemon, and start debugging the program.
+
+    .. code-block:: none
+
+        $ ./celadon_gdb.sh  wpa_supplicant
+        3207
+        Attached; pid = 3207
+        Listening on port 6000
+        
+        GNU gdb (Ubuntu 7.11.1-0ubuntu1~16.5) 7.11.1
+        Copyright (C) 2016 Free Software Foundation, Inc.
+        License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+        This is free software: you are free to change and redistribute it.
+        There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
+        and "show warranty" for details.
+        This GDB was configured as "x86_64-linux-gnu".
+        Type "show configuration" for configuration details.
+        For bug reporting instructions, please see:
+        <http://www.gnu.org/software/gdb/bugs/>.
+        Find the GDB manual and other documentation resources online at:
+        <http://www.gnu.org/software/gdb/documentation/>.
+        For help, type "help".
+        Type "apropos word" to search for commands related to "word".
+        Remote debugging from host 127.0.0.1
+        /usr/local/google/buildbot/src/android/master-ndk/toolchain/gdb/gdb-7.11/gdb/gdbserver/regcache.c:264: A problem internal to GDBserver has been detected.

--- a/source/tutorials/tutorials.rst
+++ b/source/tutorials/tutorials.rst
@@ -8,3 +8,4 @@ Guides and Tutorials
 
    add-intel-movidius-nnsdk/add-intel-movidius-nnsdk
    profiling-system-power-consumption-using-socwatch/profiling-system-power-consumption-using-socwatch
+   software-debug-tips/software-debug-tips


### PR DESCRIPTION
This commit adds the Software Debugging Tips tutorial and re-formats existing documents to reduce the use of inline literals.

Signed-off-by: Tonny Tzeng tonny.tzeng@intel.com