### PR TITLE
release_notes: preparation for adding more release notes

### DIFF
--- a/source/release_notes.rst
+++ b/source/release_notes.rst
@@ -3,6 +3,10 @@
 Release Notes
 #############
 
+.. contents:: :local:
+
+----
+
 ww201818
 ========
 


### PR DESCRIPTION
This commit uses a `contents` directive to compose a local table of content using section headers of each releases in the main release notes file.

Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>