### PR TITLE
typo: make -> mkdir

### DIFF
--- a/source/getting_started/build-source.rst
+++ b/source/getting_started/build-source.rst
@@ -15,7 +15,7 @@ Set up the development environment
 
 .. code-block:: bash
 
-    $ make -p ~/bin
+    $ mkdir -p ~/bin
     $ curl https://storage.googleapis.com/git-repo-downloads/repo >  ~/bin/repo
     $ chmod a+x ~/bin/repo
     $ export PATH=~/bin:$PATH


### PR DESCRIPTION
simply changed 'make -p ~/bin' to 'mkdir -p ~/bin'