### PR TITLE
on-brm: editorial changes

### DIFF
--- a/source/getting_started/on-bm.rst
+++ b/source/getting_started/on-bm.rst
@@ -1,40 +1,62 @@
 .. _caas-on-bm:
 
 Run |C| on Bare Metal
-=====================
+#####################
 
-Hardware
---------
+This page explains what you'll need to run |C| on bare metal.
 
-* Most of 5th, 6th, 7th or 8th SoC Generation Intel® Core and Celeron® Processors
-* Intel® E3, E5 Xeon® Processor E3 and E5 family verified
+.. contents::
+   :local:
+   :depth: 1
 
-You can try out the CaaS experience on your Intel x86 hardware platforms with UEFI BIOS and VT-x/VT-d features enabled.
+
+Hardware Prerequisites
+**********************
+
+* Most of 5th, 6th, 7th, or 8th SoC Generation Intel® Core processors and
+  Intel® Celeron® processors
+* Intel® Xeon® E3 processor family
+* Intel® Xeon® E5 processor family
+
+You can try out the :abbr:`CaaS (Celadon as a Service)` experience on your
+Intel® architecture (x86) hardware platforms with UEFI BIOS and Intel®
+Virtualization Technology (Intel® VT) for IA-32, Intel® 64 and Intel®
+Architecture (Intel® VT-x) and Intel® Virtualization Technology (Intel® VT)
+for Directed I/O (Intel® VT-d) features enabled.
 
 Configure the BIOS Setting
---------------------------
+**************************
 
-#. Depending on your bare metal target device, enter the BIOS firmware menu by pressing the hot-key (e.g. ``F2``, ``DEL``, or ``F12``) at the early of system booting-up.
+#. Depending on your bare metal target device, enter the BIOS firmware menu
+   by pressing the hotkey (e.g. :kbd:`F2`, :kbd:`DEL`, or :kbd:`F12`) at
+   the start of system bootup.
 
-#. Enable the **VT-d** and **VT-x** features in Security configuration of the BIOS if it is not enabled.
+#. Enable Intel® VT-d and Intel® VT-x features in the Security configuration
+   of the BIOS if it is not enabled.
 
-#. Disable the **Secure Boot** feature in the BIOS for live testing the CaaS features at the early stage. Secure Boot should be re-enabled later.
+#. Disable the *Secure Boot* feature in the BIOS for live testing the CaaS
+   features at the early stage. Secure Boot should be re-enabled later.
 
     .. note::
-        Do not forget to restore your previous BIOS settings after the test. Disable the secure boot may result the previous installed OS failed to boot.
+        Do not forget to restore your previous BIOS settings after the test.
+        Disabling the Secure Boot feature may result in the previously
+        installed OS failing to boot.
 
 Build Android Image
--------------------
+*******************
 
-Reference the :ref:`build-os-image` section in the Getting Started Guide to build the CaaS images.
+Refer to the :ref:`build-os-image` section in the Getting Started Guide to build the CaaS images.
 
 Flash and Boot the Device
--------------------------
+*************************
 
-The following CaaS image types generate at the end of the build:
+The following CaaS image types are generated at the end of the build:
 
 * caas.img
-    The GPT disk image for live booting on the target device. Reference the :ref:`Live Boot <usb-live-boot>` section to write the CaaS GPT image to a USB key, and boot the Android from that USB key.
+    The GPT disk image for live booting on the target device. Refer to the
+    :ref:`Live Boot <usb-live-boot>` section to write the CaaS GPT image to a USB key, and to boot Android from that USB key.
 
 * caas-flashfiles-eng.<user>.zip
-    The compressed *flashfile* package contains the kernelflinger executables. Reference :ref:`install-on-nuc` section to unzip the content of the package to a USB key, and install the CaaS images from the **UEFI Shell**.
+    The compressed *flashfile* package contains the kernelflinger executables
+    Refer to the :ref:`install-on-nuc` section to unzip the content of the
+    package to a USB key, and install the CaaS images from the *UEFI Shell*.


### PR DESCRIPTION
Editorial changes to on-brm.rst include:
- added introduction as the first paragraph
- corrected headings to use TCS-sphinx-standard  syntax
- removed extraneous capitalizations
- corrected TM&B usage
- broke lines @ 78 characters
- removed trailing whitespace
- used standard notations (i.e., :abbr:)
- cleaned-up sentence syntax

Signed-off-by: DougTW <doug.martin@intel.com>