### PR TITLE
general: fix several Sphinx compile warnings.

### DIFF
--- a/source/getting_started/build-source.rst
+++ b/source/getting_started/build-source.rst
@@ -67,7 +67,7 @@ Create an empty directory that will hold the |C| source files and serve as the w
     $ cd celadon
     $ repo init -u https://github.com/projectceladon/manifest.git
 
-The master branch of |C| build is based on Google `Android 10 <https://www.android.com/android-10/>`_ Pre-Production Early Release. Use the following command to initialize your source tree with the Google `Android 9 Pie <https://www.android.com/versions/pie-9-0/>`_ code base:
+The master branch of |C| build is based on Google `Android 10 <https://www.android.com/android-10/>`_ Pre-Production Release. Use the following command to initialize your source tree with the Google `Android 9 Pie <https://www.android.com/versions/pie-9-0/>`_ code base:
 
 .. code-block:: bash
 
@@ -102,7 +102,7 @@ Specify your |C| lunch target using the ``lunch`` command. You can run ``lunch``
 
     $ lunch celadon-userdebug
 
-The following command selects **celadon_ivi-userdebug** as the lunch target for building the `Android 10 <https://www.android.com/android-10/>`_ Pre-Production Early Release image with IVI UI:
+The following command selects **celadon_ivi-userdebug** as the lunch target for building the `Android 10 <https://www.android.com/android-10/>`_ Pre-Production Release image with IVI UI:
 
 .. code-block:: bash
 

--- a/source/getting_started/install-run.rst
+++ b/source/getting_started/install-run.rst
@@ -7,7 +7,7 @@ Prerequisites
 -------------
 
 .. caution::
-    |C| project delivers the `Android 10 <https://www.android.com/android-10/>`_ Pre-Production Early Release for evaluation and development purposes, it **MUST** not be used for production purposes.
+    |C| project delivers the `Android 10 <https://www.android.com/android-10/>`_ Pre-Production Release for evaluation and development purposes, it **MUST** not be used for production purposes.
 
 The following hardware are required to proceed with the installation.
 
@@ -135,7 +135,7 @@ In addition to the traditional Android UI launcher, |C| supports the experimenta
 .. figure:: images/ivi_ui_launcher_apps.jpg
     :align: center
 
-The following screenshots show the device running the Android 10 Pre-Production Early Release.
+The following screenshots show the device running the Android 10 Pre-Production Release.
 
 .. figure:: images/android10_home.jpg
     :align: center

--- a/source/getting_started/on-container.rst
+++ b/source/getting_started/on-container.rst
@@ -30,7 +30,7 @@ Set up Docker Engine
 #. You must install Docker on both the development host and the target
    device. Enter the following commands to install the prerequisites, set up
    the repository, and install the Docker Engine. Refer to the
-   `Get Docker Engine - Community for Ubuntu `_ installation guide for more
+   `Get Docker Engine - Community for Ubuntu`_ installation guide for more
    detailed information.
 
    .. code-block:: bash

--- a/source/getting_started/on-vm.rst
+++ b/source/getting_started/on-vm.rst
@@ -188,7 +188,7 @@ Reboot to Android UI
 
 Run the script :file:`start_android_qcow2.sh` to faciltate booting the CaaS
 images with `QEMU <https://www.qemu.org/>`_. Download the
-:file:`start_android_qcow2.sh`_ script to the working directory and change
+`start_android_qcow2.sh`_ script to the working directory and change
 the permissions on the binary executable with the following commands:
 
 .. code-block:: bash

--- a/source/release_notes.rst
+++ b/source/release_notes.rst
@@ -125,13 +125,12 @@ Important Notes and Remarks
 Known Issues
 ------------
 * Flashing time takes longer while using the kernelflinger method (~30mins), To reduce the flash time, Platform flash Tool can be used. Also the "installer.cmd" file can be altered (as per the PFT configurations) and flashed using kernel flinger method.
-• adb over wifi and ethernet works only after, ``setprop service.adb.tcp.port 5555`` and restart of USB debugging.
-• Device seen offline for 4-5 seconds on disconnect and reconnect of dbc cable.
-• Time and lock icon are displayed once on Android Start Animation when power on the DUT when connected with dual display.
-• Time flickers on All apps screen when launch Intel@Phone Doctor and touch menu button.
-• Glitch observed while the DUT is booting to UI at the intel logo screen.
+* adb over wifi and ethernet works only after, ``setprop service.adb.tcp.port 5555`` and restart of USB debugging.
+* Device seen offline for 4-5 seconds on disconnect and reconnect of dbc cable.
+* Time and lock icon are displayed once on Android Start Animation when power on the DUT when connected with dual display.
+* Time flickers on All apps screen when launch Intel@Phone Doctor and touch menu button.
+* Glitch observed while the DUT is booting to UI at the intel logo screen.
 
- 
 20-Sept-2019
 ============
 

--- a/source/tutorials/acrn_ovmf/acrn_ovmf_celadon.rst
+++ b/source/tutorials/acrn_ovmf/acrn_ovmf_celadon.rst
@@ -139,7 +139,7 @@ Run the Celadon in ACRN + OVMF
 ------------------------------
 Get launch_android.sh in /usr/share/acrn/samples/nuc/.
 
-Copy the built Celadon **[lunch_target]/[lunch_target]** *_gptimage.img to your working directory, and rename it to android.img.
+Copy the built Celadon **[lunch_target]/[lunch_target]** \*_gptimage.img to your working directory, and rename it to android.img.
 
 Get acrn-dm and ovmf.fd
 ==========================================================


### PR DESCRIPTION
This commit fixes several Sphinx compile warnings, and changes the release wording from "Pre-production Early release" to "Pre-production release" to accommodate the October quarter release. 
```
/opt/mnt/celadon-documentation/source/getting_started/on-container.rst:30: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/opt/mnt/celadon-documentation/source/getting_started/on-container.rst:30: WARNING: Inline interpreted text or phrase reference start-string without end-string.
/opt/mnt/celadon-documentation/source/getting_started/on-vm.rst:189: WARNING: Mismatch: both interpreted text role prefix and reference suffix.
/opt/mnt/celadon-documentation/source/release_notes.rst:128: WARNING: Bullet list ends without a blank line; unexpected unindent.
```
