### PR TITLE
CiV: updates for CML requirements.

### DIFF
--- a/source/getting-started/build-source.rst
+++ b/source/getting-started/build-source.rst
@@ -42,7 +42,7 @@ Set up the development environment
        $ export PATH=~/bin:$PATH
 
 #. Install the following required packages on your 64-bit Ubuntu 18.04 LTS
-   development workstation prior to starting the build:
+   development workstation prior to the compilation:
 
    .. code-block:: bash
    
@@ -57,21 +57,20 @@ Set up the development environment
             libelf-dev sbsigntool dosfstools mtools efitools \
             python-pystache git-lfs python3 flex
 
-Installing Docker\*
-===================
+#. Both :abbr:`CiV (Celadon in VM)` and :abbr:`CiC (Celadon in Container)`
+   require `Docker <https://www.docker.com/>`_ to build the images.
+   The following instructions install Docker\* on your Ubuntu development
+   workstation:
 
-:abbr:`CiV (Celadon in VM)` and :abbr:`CiC (Celadon in Container)` require
-`Docker <https://www.docker.com/>`_ to build the images. 
-
-#. Install the following packages before performing the CiV or CiC build:
+   a) Install the following packages before performing the CiV or CiC build:
 
    .. code-block:: bash
 
        $ sudo apt-get install apt-transport-https ca-certificates curl
 
-#. Execute the following commands to add the Docker's official GPG key, set
-   up the repository, and install the Docker Engine - Community from the
-   repository:
+   b) Run the following commands to add the Docker's official GPG key, set
+      up the repository, and install the *Docker Engine - Community* from the
+      repository:
 
    .. code-block:: bash
 
@@ -80,9 +79,9 @@ Installing Docker\*
        $ sudo apt-get update
        $ sudo apt-get install -y docker-ce docker-ce-cli containerd.io
 
-#. You may use Docker as a non-root user by adding your user ID to the
-   **docker** group. For more information, refer to the
-   `Get Docker Engine - Community for Ubuntu <https://docs.docker.com/install/linux/docker-ce/ubuntu/>`_ installation guide.
+   c) You may run Docker as a non-root user by adding your user ID to the
+      **docker** group. For more information, refer to the
+      `Get Docker Engine - Community for Ubuntu <https://docs.docker.com/install/linux/docker-ce/ubuntu/>`_ installation guide.
 
    .. code-block:: bash
    
@@ -109,6 +108,17 @@ Download the source
        $ mkdir civ
        $ cd civ
        $ repo init -u https://github.com/projectceladon/manifest.git
+
+   Note, the last :command:`repo init` command pulls the latest development
+   CiV source code from the the *master* branch. To checkout the source code
+   of the `QMR0 March-31-2020`_ release that passed the *Platform Exit*
+   criteria, run the following command instead:
+
+   .. _QMR0 March-31-2020: https://01.org/projectceladon/documentation/release-notes#civ-01-20-01-12-a10
+
+   .. code-block:: bash
+
+       $ repo init -u https://github.com/projectceladon/manifest -b celadon/master/2020q1 -m default.xml
 
 #. Enter the following command to pull down the |C| Android source tree to
    your working directory. The :command:`repo sync` operation might take time
@@ -144,7 +154,7 @@ Build |C| in VM image
    run :command:`lunch` with no arguments to choose different build
    variants, and select a lunch target from a list of available options.
    For example, the following commands configure the build system to
-   build the installer files for |C| in VM images with the traditional tablet UI:
+   build the installer files for |C| in VM images:
 
    .. code-block:: bash
 
@@ -155,7 +165,7 @@ Build |C| in VM image
       The *-j $(nproc)* argument instructs the builder to compile the source
       code with parallel tasks. The generated kernelflinger executables
       .ZIP file
-      (:file:`out/target/product/caas/caas.flashfiles.eng.${USER}.zip`)
+      (:file:`out/target/product/caas/caas-flashfiles-eng.${USER}.zip`)
       is available after the build. You can refer to :ref:`caas-on-vm`
       section to prepare the host environment and boot the CiV image with QEMU.
 
@@ -180,6 +190,17 @@ Download the source
        $ mkdir cic
        $ cd cic
        $ repo init -u https://github.com/projectceladon/manifest -b celadon/p/mr0/master -m cic
+
+   Note, the last :command:`repo init` command pulls the latest development
+   CiC source code from the the *master* branch. To checkout the source code of
+   the `PMR0 March-31-2020`_ release that passed the *Platform Exit*
+   criteria, run the following command instead:
+
+   .. _PMR0 March-31-2020: https://01.org/projectceladon/documentation/release-notes#cic-01-20-01-12-a09
+
+   .. code-block:: bash
+
+       $ repo init -u https://github.com/projectceladon/manifest -b celadon/p/mr0/2020q1 -m cic
 
 #. Enter the following command to pull down the |C| Android source tree to
    your working directory. The :command:`repo sync` operation might take time
@@ -215,7 +236,7 @@ Build |C| in Container package
    run :command:`lunch` with no arguments to choose different build
    variants, and select a lunch target from a list of available options.
    For example, the following commands configure the build system to
-   build the package containing |C| in Container images with the traditional tablet UI:
+   build the package containing |C| in Container images:
 
    .. code-block:: bash
 
@@ -225,6 +246,6 @@ Build |C| in Container package
    .. note::
       The *-j $(nproc)* argument instructs the builder to compile the source
       code with parallel tasks. The generated CiC package
-      (:file:`out/target/product/cic/cic-${USER}.tar.gz`)
+      (:file:`out/target/product/cic/cic-aic-eng.${USER}.<time code>.tar.gz`)
       is available after the build. You can follow :ref:`deploy-cic-on-target` of
       this guide to deploy and start the CiC container on the target device.

--- a/source/getting-started/on-vm.rst
+++ b/source/getting-started/on-vm.rst
@@ -12,15 +12,21 @@ This page explains what you'll need to run |C| in a virtual machine.
 Prerequisites
 *************
 
-* Ubuntu 18.04.3 or higher running Linux\* kernel version 5.0.0 or above.
+* A |NUC| device installed Ubuntu 18.04.3 or higher running Linux\* kernel
+  version 5.0.0 or above.
+
+  .. note::
+     :abbr:`CiV (Celadon in VM)` releases have been validated on
+     |NUC| model `NUC7i5DNHE`_. Releases after **April 17th 2020** are
+     validated on |NUC| model `NUC10i7FNK`_ and `NUC10i7FNH`_ to
+     take performance advantages of 10th Generation Intel® Core Processors.
 
 Prepare the host environment
 ****************************
 
+The host device that launches the virtual machine requires Ubuntu 18.04.
 To simpify the preparation works, a helper script :file:`setup_host.sh` is
 provided.
-The host device that launches the virtual machine requires Linux kernel
-version 5.0.0 or above running as the host OS, Ubuntu 18.04 is prerequisite.
 Complete the following instructions to set up Docker\* and the required
 software on Ubuntu 18.04.3 before running |C| in a VM with `QEMU`_.
 During the installation, you will be prompted by some questions to confirm the
@@ -32,6 +38,22 @@ changes to the packages, it's safe to respond :kbd:`y` to all of them.
         $ wget https://raw.githubusercontent.com/projectceladon/device-androidia-mixins/master/groups/device-specific/caas/setup_host.sh
         $ chmod +x setup_host.sh
         $ sudo -E ./setup_host.sh
+
+The Linux kernel is extremely important on every Android devices, Google
+recommends using `AOSP common kernels`_ on Android devices to include
+features and implementations required by Android.
+In addition to the AOSP common kernel, |C| also integrates several
+`staging patches <https://github.com/projectceladon/vendor-intel-utils/tree/master/host/kernel/lts2019-chromium>`_
+to take advantages of high performance new Intel processors,
+so it's strongly recommended to run the |C| kernel as the host OS,
+especially running CiV on `NUC10i7FNK`_ or `NUC10i7FNH`_ |NUC| devices.
+To that end, a
+`helper script <https://github.com/projectceladon/vendor-intel-utils/blob/master/host/kernel/lts2019-chromium/build.sh>`_
+:file:`build.sh` is designed to facilitate
+the building and deploying of |C| kerenl on the Ubuntu host.
+Refer to the `README`_ for more detailed instructions.
+
+.. _README: https://github.com/projectceladon/vendor-intel-utils/blob/master/host/kernel/lts2019-chromium/README
 
 Build |C| images running in VM
 ******************************
@@ -88,16 +110,10 @@ file `android.qcow2` is hard-coded in the script:
 
 .. code-block:: bash
 
-    ...
-    function launch_*render(){
-        qemu-system-x86_64 \
-        -m 2048 -smp 2 -M q35 \
-        -name celadon-vm \
-        -enable-kvm \
-        ...
-        -drive file=./android.qcow2,if=none,id=disk1 \  ### Edit the CiV image file name on the left
-        ...
-    }
+    #!/bin/bash
+
+    work_dir=$PWD
+    caas_image=$work_dir/android.qcow2
     ...
 
 Enter the following commands to run the script :file:`start_android_qcow2.sh` with
@@ -117,3 +133,11 @@ root permissions to facilitate the booting of CiV images with `QEMU <https://www
 .. _QEMU: https://www.qemu.org/
 
 .. _start_android_qcow2.sh: https://raw.githubusercontent.com/projectceladon/device-androidia-mixins/master/groups/device-specific/caas/start_android_qcow2.sh
+
+.. _NUC7i5DNHE: https://www.intel.com/content/www/us/en/products/boards-kits/nuc/kits/nuc7i5dnhe.html
+
+.. _NUC10i7FNK: https://www.intel.com/content/www/us/en/products/boards-kits/nuc/kits/nuc10i7fnk.html
+
+.. _NUC10i7FNH: https://www.intel.com/content/www/us/en/products/boards-kits/nuc/kits/nuc10i7fnh.html
+
+.. _AOSP common kernels: https://source.android.com/devices/architecture/kernel/android-common


### PR DESCRIPTION
This commit adds changes required for running CiV on CML NUC using April-17-2020 onward builds.