### PR TITLE
build-source.rst Added missing instruction line 62.

### DIFF
--- a/source/getting-started/build-source.rst
+++ b/source/getting-started/build-source.rst
@@ -59,6 +59,7 @@ Set up the development environment
             libssl-dev bc bsdmainutils gettext python-mako \
             libelf-dev sbsigntool dosfstools mtools efitools \
             python-pystache git-lfs python3 flex clang libncurses5
+      $ sudo apt install cryptsetup-bin
 
 #. :abbr:`CiC (Celadon in Container)`
    requires `Docker <https://www.docker.com/>`_ to build the images.


### PR DESCRIPTION
sudo apt install cryptsetup-bin 
per Sundar email
Signed-off-by: Doug Martin <doug.martin@intel.com>