### PR TITLE
build-source.rst

### DIFF
--- a/source/getting-started/build-source.rst
+++ b/source/getting-started/build-source.rst
@@ -120,7 +120,7 @@ Download the source
 
    .. code-block:: bash
 
-       $ repo init -u https://github.com/projectceladon/manifest  -b celadon/q/mr0/stable -m default.xml
+       $ repo init -u https://github.com/projectceladon/manifest  -b celadon/q/mr0/stable -m stable-build/CIV_00.20.03.31_A10.xml
 
    You can also checkout the source code
    of the `QMR0 March-31-2020`_ release that passed the *Platform Exit*


### PR DESCRIPTION
Fixed 'repo-init' command for Android 10 based source code

Signed-off-by: Doug Martin <doug.martin@intel.com>