### PR TITLE
Stable-celadon_iot external releaseQ3'22-2

### DIFF
--- a/source/release-notes.rst
+++ b/source/release-notes.rst
@@ -27,7 +27,13 @@ CIV_03.22.03.37_A11
 Intended audience
 -----------------
 
-* Celadon open Source Community
+* Celadon Open Source Community who has subscribed to celadon@lists.linuxfoundation.org 
+
+Customer support
+----------------
+
+* subscribe/unsubscribe celadon mailing list using :
+  https://lists.01.org/postorius/lists/celadon.lists.01.org/
 
 Introduction
 ------------


### PR DESCRIPTION
Stable-release_iot release details documentation for external releases ,push with Q3_Sep'22 -2 for documentation Below Pages are Modified: Release Notes : With linux.org 
Intended audience
Open Source Community who has subscribed to celadon@lists.linuxfoundation.org

Signed-off-by: Sivaramakrishnan, UdhayanX udhayanx.sivaramakrishnan@intel.com